### PR TITLE
added tolower fix for capitalized col names from db

### DIFF
--- a/R/cdm.R
+++ b/R/cdm.R
@@ -304,6 +304,7 @@ verify_write_access <- function(con, write_schema, add = NULL) {
 
   withr::with_options(list(databaseConnectorIntegerAsNumeric = FALSE), {
     df2 <- DBI::dbReadTable(con, DBI::SQL(tablename))
+    names(df2) <- tolower(names(df2))
   })
 
   DBI::dbRemoveTable(con, DBI::SQL(tablename))


### PR DESCRIPTION
df1 is defined as:
| chr_col | numeric_col |
| --- | --- |
| 'a' | 1 |

df2 would be fetched from SQLite as:
| CHR_COL| NUMERIC_COL |
| --- | --- |
| 'a' | 1 |

failing the following [check](https://github.com/darwin-eu-dev/CDMConnector/blob/main/R/cdm.R#L311:L321):
```
if (!isTRUE(dplyr::all_equal(df1, df2))) {
  msg <- paste("Write access to schema",
               write_schema,
               "could not be verified.")

  if (is.null(add)) {
    rlang::abort(msg)
  } else {
    add$push(msg)
  }
}
```

```
names(df2) <- tolower(names(df2))
```

would fix this issue, passing the check.

I verified that it would work as follows:

```
con <- DBI::dbConnect(
  DatabaseConnector::DatabaseConnectorDriver(),
  dbms = "sqlite",
  server = "..\\Temp\\Rtmpm8Kzj7\\file584c5526306b.sqlite")

cdm <- CDMConnector::cdmFromCon(
  con = con,
  writeSchema = "main",
  # cohortTableNames are generated by CohortGenerator.
  cohortTables = unlist(cohortTableNames))

cdm$cohort_table %>% 
  group_by(cohort_definition_id) %>% 
  tally()
```

Which yields:
```
# Source:   SQL [7 x 2]
# Database: DatabaseConnectorDbiConnection
  cohort_definition_id     n
                 <dbl> <dbl>
1                    1  2679
2                    2  2130
3                    3  1927
4                    4  2021
5                    5  1393
6                    6  1732
7                    7  2159
```

Which is expected.