### PR TITLE
Compatibility with dev dbplyr

### DIFF
--- a/R/compute.R
+++ b/R/compute.R
@@ -56,13 +56,10 @@
 
   DBI::dbExecute(x$src$con, sql)
 
-  if (methods::is(x$src$con, "duckdb_connection")) {
-    ref <- dplyr::tbl(x$src$con, paste(c(schema, name), collapse = "."))
-  } else if (length(schema) == 2) {
-    ref <- dplyr::tbl(x$src$con,
-                      dbplyr::in_catalog(schema[[1]], schema[[2]], name))
+  if (length(schema) == 2) {
+    ref <- dplyr::tbl(x$src$con, DBI::Id(catalog = schema[[1]], schema = schema[[2]], table = name))
   } else if (length(schema) == 1) {
-    ref <- dplyr::tbl(x$src$con, dbplyr::in_schema(schema, name))
+    ref <- dplyr::tbl(x$src$con, DBI::Id(schema = schema, table = name))
   } else {
     ref <- dplyr::tbl(x$src$con, name)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -45,9 +45,6 @@ inSchema <- function(schema, table, dbms = NULL) {
     switch(length(schema),
            dbplyr::in_schema(schema = schema, table = table),
            dbplyr::in_catalog(catalog = schema[1], schema = schema[2], table = table))
-  } else if (isTRUE(dbms == "duckdb")) {
-    checkmate::assertCharacter(schema, len = 1)
-    paste0(schema, ".", table)
   } else {
     switch(length(schema),
            DBI::Id(schema = schema, table = table),


### PR DESCRIPTION
dbplyr now  warns when the table name contains a `.`, as in most cases you actually want to specify a table in a schema. Your package came up in the revdepchecks as it also faced this issue. This PR should make it compatible with the new dev version.
Note that I'm not entirely sure whether everything is fixed as I got an error `Exited with status 137.` when running the test suite.