### PR TITLE
constant DBI::Id output

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -65,9 +65,9 @@ inSchema <- function(schema, table, dbms = NULL) {
   if (is.null(schema)) {
     # return temp table name
     if (dbms == "sql server") {
-      return(paste0("#", table))
+      return(DBI::Id(table = paste0("#", table)))
     }
-    return(table)
+    return(DBI::Id(table = table))
   }
 
   if ("prefix" %in% names(schema)) {
@@ -92,12 +92,12 @@ inSchema <- function(schema, table, dbms = NULL) {
   schema <- unname(schema)
 
   # if (isTRUE(dbms %in% c("bigquery"))) { #TODO bigrquery needs to fix this
-  if (!is.null(dbms) && dbms == "duckdb" && schema == "main") {
+  out <- if (!is.null(dbms) && dbms == "duckdb" && schema == "main") {
     checkmate::assertCharacter(schema, len = 1)
     # out <- paste(c(schema, table), collapse = ".")
-    out <- table
+    DBI::Id(table = table)
   } else {
-    out <- switch(length(schema),
+    switch(length(schema),
       DBI::Id(schema = schema, table = table),
       DBI::Id(catalog = schema[1], schema = schema[2], table = table))
   }


### PR DESCRIPTION
The table reference was not always returned as the output of `DBI::Id()`. This seemed to cause issues on Spark.

Additionally I found that for Spark specifically `useNativeQuery = FALSE` must be set in the connection, according to this issue: https://github.com/r-dbi/odbc/issues/544

@ablack3 @IoannaNika Could you please review?