### PR TITLE
Fixing `generateCohortSet()` on DataBricks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: CDMConnector
 Title: Connect to an OMOP Common Data Model
-Version: 2.2.0
+Version: 2.2.0.9999
 Authors@R: c(
     person("Adam", "Black", , "black@ohdsi.org", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5576-8701")),

--- a/R/generateCohortSet.R
+++ b/R/generateCohortSet.R
@@ -491,7 +491,12 @@ generateCohortSet <- function(cdm,
       # we need temp emulation on spark as there are no temp tables
 
       if ("schema" %in% names(write_schema)) {
-        s <- unname(write_schema["schema"])
+        if ("catalog" %in% names(write_schema)) {
+          s <- write_schema_sql
+        } else {
+          s <- unname(write_schema["schema"])
+        }
+
       } else if (length(write_schema) == 1) {
         s <- unname(write_schema)
       } else {


### PR DESCRIPTION
Addresses issue https://github.com/darwin-eu/CDMConnector/issues/40

I'm unsure why `s` isn't always set to `write_schema_sql`, so I wrote conservative code that only changes behavior when `write_schema` has a `catalog` entry. You may consider just always setting `s` to `write_schema_sql`?