### PR TITLE
Feature/list violating table names

### DIFF
--- a/R/cdm.R
+++ b/R/cdm.R
@@ -189,7 +189,20 @@ cdmFromCon <- function(con,
   if (all(cdm_tables_in_db == toupper(cdm_tables_in_db))) {
     omop_tables <- toupper(omop_tables)
   } else if (!all(cdm_tables_in_db == tolower(cdm_tables_in_db))) {
-    rlang::abort("CDM database tables should be either all upppercase or all lowercase!")
+    uppercase_tables <- cdm_tables_in_db[cdm_tables_in_db == toupper(cdm_tables_in_db)]
+    lowercase_tables <- cdm_tables_in_db[cdm_tables_in_db == tolower(cdm_tables_in_db)]
+    mixed_tables <- cdm_tables_in_db[
+      cdm_tables_in_db != toupper(cdm_tables_in_db) &
+        cdm_tables_in_db != tolower(cdm_tables_in_db)
+    ]
+
+    rlang::abort(c(
+      "CDM database tables should be either all upppercase or all lowercase!",
+      "x" = "Mixed casing detected for CDM tables.",
+      "i" = "Uppercase tables: {paste(uppercase_tables, collapse = ', ')}",
+      "i" = "Lowercase tables: {paste(lowercase_tables, collapse = ', ')}",
+      "i" = "Mixed-case tables: {paste(mixed_tables, collapse = ', ')}"
+    ))
   }
 
   cdmTables <- purrr::map(

--- a/R/cdm.R
+++ b/R/cdm.R
@@ -196,12 +196,28 @@ cdmFromCon <- function(con,
         cdm_tables_in_db != tolower(cdm_tables_in_db)
     ]
 
+    uppercase_msg <- if (length(uppercase_tables) > 0) {
+      paste(uppercase_tables, collapse = ", ")
+    } else {
+      "none"
+    }
+    lowercase_msg <- if (length(lowercase_tables) > 0) {
+      paste(lowercase_tables, collapse = ", ")
+    } else {
+      "none"
+    }
+    mixed_msg <- if (length(mixed_tables) > 0) {
+      paste(mixed_tables, collapse = ", ")
+    } else {
+      "none"
+    }
+
     rlang::abort(c(
       "CDM database tables should be either all upppercase or all lowercase!",
       "x" = "Mixed casing detected for CDM tables.",
-      "i" = "Uppercase tables: {paste(uppercase_tables, collapse = ', ')}",
-      "i" = "Lowercase tables: {paste(lowercase_tables, collapse = ', ')}",
-      "i" = "Mixed-case tables: {paste(mixed_tables, collapse = ', ')}"
+      "i" = paste0("Uppercase tables: ", uppercase_msg),
+      "i" = paste0("Lowercase tables: ", lowercase_msg),
+      "i" = paste0("Mixed-case tables: ", mixed_msg)
     ))
   }
 

--- a/R/cdm.R
+++ b/R/cdm.R
@@ -185,41 +185,7 @@ cdmFromCon <- function(con,
   if (length(omop_tables) == 0) {
     rlang::abort("There were no cdm tables found in the cdm_schema!")
   }
-  cdm_tables_in_db <- dbTables[which(tolower(dbTables) %in% omop_tables)]
-  if (all(cdm_tables_in_db == toupper(cdm_tables_in_db))) {
-    omop_tables <- toupper(omop_tables)
-  } else if (!all(cdm_tables_in_db == tolower(cdm_tables_in_db))) {
-    uppercase_tables <- cdm_tables_in_db[cdm_tables_in_db == toupper(cdm_tables_in_db)]
-    lowercase_tables <- cdm_tables_in_db[cdm_tables_in_db == tolower(cdm_tables_in_db)]
-    mixed_tables <- cdm_tables_in_db[
-      cdm_tables_in_db != toupper(cdm_tables_in_db) &
-        cdm_tables_in_db != tolower(cdm_tables_in_db)
-    ]
-
-    uppercase_msg <- if (length(uppercase_tables) > 0) {
-      paste(uppercase_tables, collapse = ", ")
-    } else {
-      "none"
-    }
-    lowercase_msg <- if (length(lowercase_tables) > 0) {
-      paste(lowercase_tables, collapse = ", ")
-    } else {
-      "none"
-    }
-    mixed_msg <- if (length(mixed_tables) > 0) {
-      paste(mixed_tables, collapse = ", ")
-    } else {
-      "none"
-    }
-
-    rlang::abort(c(
-      "CDM database tables should be either all upppercase or all lowercase!",
-      "x" = "Mixed casing detected for CDM tables.",
-      "i" = paste0("Uppercase tables: ", uppercase_msg),
-      "i" = paste0("Lowercase tables: ", lowercase_msg),
-      "i" = paste0("Mixed-case tables: ", mixed_msg)
-    ))
-  }
+  omop_tables <- validateCdmTableCase(dbTables = dbTables, omopTables = omop_tables)
 
   cdmTables <- purrr::map(
     omop_tables, ~ dplyr::tbl(src = src, schema = cdmSchema, name = .)
@@ -328,6 +294,49 @@ cdmFromCon <- function(con,
   attr(cdm, "dbcon") <- attr(attr(cdm, "cdm_source"), "dbcon")
 
   return(cdm)
+}
+
+validateCdmTableCase <- function(dbTables, omopTables) {
+  cdm_tables_in_db <- dbTables[which(tolower(dbTables) %in% omopTables)]
+
+  if (all(cdm_tables_in_db == toupper(cdm_tables_in_db))) {
+    return(toupper(omopTables))
+  }
+
+  if (!all(cdm_tables_in_db == tolower(cdm_tables_in_db))) {
+    uppercase_tables <- cdm_tables_in_db[cdm_tables_in_db == toupper(cdm_tables_in_db)]
+    lowercase_tables <- cdm_tables_in_db[cdm_tables_in_db == tolower(cdm_tables_in_db)]
+    mixed_tables <- cdm_tables_in_db[
+      cdm_tables_in_db != toupper(cdm_tables_in_db) &
+        cdm_tables_in_db != tolower(cdm_tables_in_db)
+    ]
+
+    uppercase_msg <- if (length(uppercase_tables) > 0) {
+      paste(uppercase_tables, collapse = ", ")
+    } else {
+      "none"
+    }
+    lowercase_msg <- if (length(lowercase_tables) > 0) {
+      paste(lowercase_tables, collapse = ", ")
+    } else {
+      "none"
+    }
+    mixed_msg <- if (length(mixed_tables) > 0) {
+      paste(mixed_tables, collapse = ", ")
+    } else {
+      "none"
+    }
+
+    rlang::abort(c(
+      "CDM database tables should be either all upppercase or all lowercase!",
+      "x" = "Mixed casing detected for CDM tables.",
+      "i" = paste0("Uppercase tables: ", uppercase_msg),
+      "i" = paste0("Lowercase tables: ", lowercase_msg),
+      "i" = paste0("Mixed-case tables: ", mixed_msg)
+    ))
+  }
+
+  return(omopTables)
 }
 
 #' @importFrom dplyr tbl


### PR DESCRIPTION
List violating table names rather than just the error `CDM database tables should be either all upppercase or all lowercase!`

Move the validation to another method.

Example violation output 

<img width="1382" height="1734" alt="image" src="https://github.com/user-attachments/assets/eac2a021-70ee-4b94-9f97-2ce59b32bd64" />
