### PR TITLE
Add "PostgreSQL" (ODBC) to list of supported connection classes

### DIFF
--- a/R/cdm.R
+++ b/R/cdm.R
@@ -632,6 +632,7 @@ result <- if (inherits(con, "Microsoft SQL Server")) {
   supported_con <- c(
     "Microsoft SQL Server",
     "PqConnection",
+    "PostgreSQL",
     "RedshiftConnection",
     "BigQueryConnection",
     "SQLiteConnection",

--- a/R/cdm.R
+++ b/R/cdm.R
@@ -609,6 +609,8 @@ result <- if (inherits(con, "Microsoft SQL Server")) {
   "redshift"
 } else if (inherits(con, "PqConnection")) {
   "postgresql"
+} else if (inherits(con, "PostgreSQL")) {
+  "postgresql"
 } else if (inherits(con, "BigQueryConnection")) {
   "bigquery"
 } else if (inherits(con, "SQLiteConnection")) {


### PR DESCRIPTION
When connected to PostgreSQL with ODBC instead of RPostgres, the connection class is PostgreSQL. This PR adds it to the dbms list.

Closes #58 